### PR TITLE
fix: Allow skipping aliased hooks

### DIFF
--- a/pre_commit_ci_config.py
+++ b/pre_commit_ci_config.py
@@ -29,6 +29,12 @@ class ValidateSkip:
             for repo in dct['repos']
             for hook in repo['hooks']
         }
+        all_aliases = {
+            hook.get('alias')
+            for repo in dct['repos']
+            for hook in repo['hooks']
+        }
+        all_ids.update(all_aliases)
         unexpected_skip = set(dct.get('ci', {}).get('skip', ())) - all_ids
         if unexpected_skip:
             with cfgv.validate_context('At key: ci'):

--- a/tests/pre_commit_ci_config_test.py
+++ b/tests/pre_commit_ci_config_test.py
@@ -94,6 +94,24 @@ def test_skip_referencing_missing_hook():
     )
 
 
+def test_skip_references_hook_with_alias():
+    cfg = {
+        'ci': {'skip': ['alternate-identity']},
+        'repos': [
+            {
+                'repo': 'meta',
+                'hooks': [
+                    {
+                        'id': 'identity',
+                        'alias': 'alternate-identity',
+                    },
+                ],
+            },
+        ],
+    }
+    cfgv.validate(cfg, SCHEMA)
+
+
 def test_main_ok(tmpdir):
     cfg_s = '''\
 ci:


### PR DESCRIPTION
There are situations where a hook with the same ID will be used multiple times, but with differing configurations. In the event that one of those configurations should not desired (or can't) be run in pre-commit CI it should be possible to skip using the `alias` configuration parameter. This adds support for the `alias` as an alternate to just `id` in the `ci:skip` list.